### PR TITLE
Add error message to missing description

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,3 +4,4 @@ class User < ActiveRecord::Base
   validates :email, presence: true, uniqueness: {case_sensitive: false}
   validates :name, presence: true, uniqueness: {case_sensitive: false}
 end
+

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [@task_list, @task], html: { class: "task-form" } do |f| %>
+<%= form_for [:task_list, @task], html: { class: "task-form" } do |f| %>
 
   <h2>Add a Task</h2>
 


### PR DESCRIPTION
Page would blow up if user forgot to add description to new task. Fixed bug by switching '@' with ':'.  @ identifies an empty object and : identifies an array - in this case a string for the description. 
