### PR TITLE
Bug Fix and Test Fix

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,7 @@ class TasksController < ApplicationController
 
   def create
     task_params = params.require(:task).permit(:description, :due_date).merge(task_list_id: params[:task_list_id])
+    @task_list = TaskList.find(params[:task_list_id])
     @task = Task.new(task_params)
     if @task.save
       redirect_to root_path, notice: "Task was created successfully!"

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -8,7 +8,7 @@
 
   <div class="form-row">
     <%= f.label :description, class: "form-label" %>
-    <%= f.text_field :description %>
+    <%= f.text_field :description, :required => true %>
   </div>
 
   <div class="form-row">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -2,18 +2,18 @@
 
   <h2>Add a Task</h2>
 
-  <% if f.object.errors.full_messages.each do |error| %>
+  <% if f.object.errors.any? %>
     <div class="error">Your task could not be created</div>
   <% end %>
 
   <div class="form-row">
     <%= f.label :description, class: "form-label" %>
-    <%= f.text_field :description %>
+    <%= f.text_field :description, :error => false%>
   </div>
 
   <div class="form-row">
     <%= f.label :due_date, class: "form-label" %>
-    <%= f.date_select :due_date %>
+    <%= f.date_select :due_date, :error => false %>
   </div>
 
   <div class="form-row">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -2,13 +2,13 @@
 
   <h2>Add a Task</h2>
 
-  <% if f.object.errors.any? %>
+  <% if f.object.errors.full_messages.each do |error| %>
     <div class="error">Your task could not be created</div>
   <% end %>
 
   <div class="form-row">
     <%= f.label :description, class: "form-label" %>
-    <%= f.text_field :description, :required => true %>
+    <%= f.text_field :description %>
   </div>
 
   <div class="form-row">

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -18,7 +18,7 @@ feature 'Tasks' do
 
     expect(page).to have_content("Something important")
     expect(page).to have_content("Task was created successfully!")
-    expect(page).to have_content("2 days")
+    expect(page).to have_content("1 day")
   end
 
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -21,4 +21,13 @@ feature 'Tasks' do
     expect(page).to have_content("1 day")
   end
 
+  scenario 'User goes back to /task_lists/ with an error when not putting in a description' do
+    user = create_user email: "user@example.com"
+    TaskList.create(name: "Work List")
+
+    login(user)
+    click_on "+ Add Task", match: :first
+    click_on "Create Task"
+    expect(current_path).to match('/task_lists/')
+  end
 end


### PR DESCRIPTION
Bug: When signed in and entering a task, if description is left empty the entire website crashes without showing an error message.
Fix: recalled the @task_list in the task controller inside the create function. Another way would be to create a validation on the page itself (which I did at an earlier commit) but the error message inside the div would be totally useless.
Test: Also, there was a tiny error with one of the tests; it didn't have the correct date input in words. Corrected it from '2 days' to '1 day.' I also added my own test to see if you'll be routed back to the task_list page 
